### PR TITLE
Fix v_string test to work with modern version.pm

### DIFF
--- a/t/30_v_string.t
+++ b/t/30_v_string.t
@@ -14,9 +14,8 @@ my $scanner = Perl::PrereqScanner::Lite->new;
 subtest 'basic' => sub {
     my $got = $scanner->scan_file(catfile($FindBin::Bin, 'resources', 'v_string.pl'));
     cmp_deeply(get_reqs_hash($got), {
-        'File::Temp' => 'v0.1_2',
+        'File::Temp' => any('v0.1_2', 'v0.12.0')
     });
 };
 
 done_testing;
-


### PR DESCRIPTION
New versions of version.pm normalize the version string.
